### PR TITLE
fix(group): fix group sort error

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -410,9 +410,7 @@ const Command = React.forwardRef<HTMLDivElement, CommandProps>((props, forwarded
     groups
       .sort((a, b) => b[1] - a[1])
       .forEach((group) => {
-        const element = listInnerRef.current?.querySelector(
-          `${GROUP_SELECTOR}[${VALUE_ATTR}="${encodeURIComponent(group[0])}"]`,
-        )
+        const element = listInnerRef.current?.querySelector(`#${group[0].replace(/:/g, '\\:')}`)
         element?.parentElement.appendChild(element)
       })
   }
@@ -742,6 +740,7 @@ const Group = React.forwardRef<HTMLDivElement, GroupProps>((props, forwardedRef)
       cmdk-group=""
       role="presentation"
       hidden={render ? undefined : true}
+      id={id}
     >
       {heading && (
         <div ref={headingRef} cmdk-group-heading="" aria-hidden id={headingId}>


### PR DESCRIPTION
Fix the issue with group sorting not working. The root cause of the error is using the group ID to match the data-value.